### PR TITLE
feat: add input label for novo-imovel form

### DIFF
--- a/assets/css/novo-imovel.css
+++ b/assets/css/novo-imovel.css
@@ -1,112 +1,122 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@200;300;400;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@200;300;400;700&display=swap");
 
-*{
-    font-family: 'Montserrat', sans-serif;
-    padding: 0px;
-    margin: 0px;
-    text-decoration: none;
-    list-style: none;
-    color: inherit;
-    transition: all 0.3s ease-in;
+* {
+  font-family: "Montserrat", sans-serif;
+  padding: 0px;
+  margin: 0px;
+  text-decoration: none;
+  list-style: none;
+  color: inherit;
+  transition: all 0.3s ease-in;
 }
 
-body{
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
 }
 
-form{
-    width: 80%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 2rem;
-    border: 1px solid #213644;
+form {
+  width: 80%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  border: 1px solid #213644;
 }
 
-form h3{
-    width: 100%;
-    text-align: center;
-    font-size: 250%;
+form h3 {
+  width: 100%;
+  text-align: center;
+  font-size: 250%;
 }
 
-form .inputs{  
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: flex-start;
-    margin: 2rem;
+form .inputs {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  margin: 2rem;
 }
 
-form .inputs input{
-    width: 300px;
-    height: 2rem;
+form .inputs input {
+  width: 300px;
+  height: 2rem;
 }
 
-form .inputs select{
-    width: 300px;
-    height: 2rem;
+form .inputs select {
+  width: 300px;
+  height: 2rem;
 }
 
-form i{
-    font-size: 150%;
+form i {
+  font-size: 150%;
 }
 
-.inicio{
-    width: 80%;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-top: 5rem;
-    padding: 2rem;
-    background-color: #213644;
-    border: 1px solid #213644;
-    color: #ffffff;
+.inicio {
+  width: 80%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 5rem;
+  padding: 2rem;
+  background-color: #213644;
+  border: 1px solid #213644;
+  color: #ffffff;
 }
 
-.inicio .buttons{
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
+.inicio .buttons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
 }
 
-.inicio button{
-    width: 150px;
-    font-size: 130%;
-    background-color: #C6AB7C;
-    color: #213644;
-    border: 0.5px solid #C6AB7C;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+.inicio button {
+  width: 150px;
+  font-size: 130%;
+  background-color: #c6ab7c;
+  color: #213644;
+  border: 0.5px solid #c6ab7c;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-.inicio button:hover{
-    background-color: transparent;
-    color: #C6AB7C;
-    border: 0.5px solid #C6AB7C;
+.inicio button:hover {
+  background-color: transparent;
+  color: #c6ab7c;
+  border: 0.5px solid #c6ab7c;
 }
 
-.inicio .sair{
-    width: 70px;
-    font-size: 160%;
-    background-color: #bb2020;
-    color: #213644;
-    border: 0.5px solid #bb2020;
+.inicio .sair {
+  width: 70px;
+  font-size: 160%;
+  background-color: #bb2020;
+  color: #213644;
+  border: 0.5px solid #bb2020;
 }
 
-.inicio h3{
-    font-size: 200%;
+.inicio h3 {
+  font-size: 200%;
 }
 
-.submit{
-    width: 100%;
-    height: 2rem;
-    background-color: #213644;
-    color: #C6AB7C;
-    font-size: 130%;
-    border: 1px solid #213644;
+.submit {
+  width: 100%;
+  height: 2rem;
+  background-color: #213644;
+  color: #c6ab7c;
+  font-size: 130%;
+  border: 1px solid #213644;
+}
+
+.inputs .flex {
+  display: flex;
+  justify-content: center;
+  gap: 2;
+}
+
+.inputs input {
+  margin-top: 5px;
 }

--- a/novo-imovel.html
+++ b/novo-imovel.html
@@ -1,140 +1,191 @@
 <!DOCTYPE html>
 <html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Novo Imóvel</title>
 
-    <link rel="stylesheet" href="assets/css/novo-imovel.css">
+    <link rel="stylesheet" href="assets/css/novo-imovel.css" />
 
     <!-- Boxicons CSS -->
-    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
-</head>
-<body>
-
+    <link
+      href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
     <div class="inicio">
-        <h3>Novo Imóvel</h3>
-        
-        <div class="buttons">
-            <button class="sair" onclick = "voltar()"><i class='bx bx-chevron-left' ></i></button>
-        </div>
-        
+      <h3>Novo Imóvel</h3>
+
+      <div class="buttons">
+        <button class="sair" onclick="voltar()">
+          <i class="bx bx-chevron-left"></i>
+        </button>
+      </div>
     </div>
-    <form action="application/novo-imovel.php" method="POST" enctype="multipart/form-data">
-        
-        <div class="inputForms">
-            <h3>Cadastrar novo Imóvel</h3>
-            <input type="text" value="NOVO" name="txtID" hidden>
+    <form
+      action="application/novo-imovel.php"
+      method="POST"
+      enctype="multipart/form-data"
+    >
+      <div class="inputForms">
+        <h3>Cadastrar novo Imóvel</h3>
+        <input type="text" value="NOVO" name="txtID" hidden />
 
-            <div class="inputs">
-               <label for="txtDesc">Descrição</label>
-                <input type="text" name="txtDesc" required> 
-            </div>
-    
-            <div class="inputs">
-                <label for="txtlocal">localização</label>
-                 <input type="text" name="txtLocal" required> 
-             </div>
-    
-             <div class="inputs">
-                <label for="txtpreco">Preco</label>
-                 <input type="text" name="txtPreco" oninput="formatarDinheiro(this)" required> 
-             </div>
-            
-    
-             <div class="inputs">
-                <i class='bx bxs-building-house'></i>
-                <input type="number" name="txtAndares" value="1" min="0" max="10" required> 
-             </div>
-    
-             <div class="inputs">
-                <i class='bx bxs-bed'></i>
-                 <input type="number" name="txtQuartos" value="1" min="0" max="10" required> 
-             </div>
-    
-             <div class="inputs">
-                <i class='bx bxs-car'></i>
-                 <input type="number" name="txtCarros" value="1" min="0" max="10" required> 
-             </div>
-    
-             <div class="inputs">
-                <i class='bx bxs-area' ></i>
-                 <input type="text" name="txtArea" oninput="formatarMetros(this)" required> 
-             </div>
-    
-             <div class="inputs">
-                <select name="txtSituacao" required>
-    
-                    <option value="">Situação...</option>
-                    <option value="1">Disponível</option>
-                    <option value="0">Indisponível</option>
-                </select>
-             </div>
+        <div class="inputs">
+          <label for="txtDesc">Descrição</label>
+          <input type="text" name="txtDesc" required />
         </div>
 
-        
-        
-        <div class="image">
-            <div>
-                <label class="form-label">Pré Visualização</label>
-                <img style="display: block; margin: 0 auto; height: 300px; " src="assets/images/foto-chave.png" id="img_foto">
-                <input type="hidden" id="txt_foto" name="txt_foto">
-
-                <div class="inputs">
-                    <input type="file" accept="image/*" name="file_imagem" id="file_imagem" onchange="visualizarIMG(this)">
-                </div>
-            </div>
-
-            <input type="submit" value="Enviar" class="submit">
+        <div class="inputs">
+          <label for="txtlocal">Localização</label>
+          <input type="text" name="txtLocal" required />
         </div>
-         
+
+        <div class="inputs">
+          <label for="txtpreco">Preco</label>
+          <input
+            type="text"
+            name="txtPreco"
+            oninput="formatarDinheiro(this)"
+            required
+          />
+        </div>
+
+        <div class="inputs flex">
+          <div class="flex">
+            <i class="bx bxs-building-house"></i>
+            <span>Andar</span>
+          </div>
+          <input
+            type="number"
+            name="txtAndares"
+            value="1"
+            min="0"
+            max="10"
+            required
+          />
+        </div>
+
+        <div class="inputs">
+          <div class="flex">
+            <i class="bx bxs-bed"></i>
+            <span>Qtd. Quartos</span>
+          </div>
+          <input
+            type="number"
+            name="txtQuartos"
+            value="1"
+            min="0"
+            max="10"
+            required
+          />
+        </div>
+
+        <div class="inputs flex">
+          <div class="flex">
+            <i class="bx bxs-car"></i>
+            <span>Qtd. Vagas na Garagem</span>
+          </div>
+          <input
+            type="number"
+            name="txtCarros"
+            value="1"
+            min="0"
+            max="10"
+            required
+          />
+        </div>
+
+        <div class="inputs flex">
+          <div class="flex">
+            <i class="bx bxs-area"></i>
+            <span>Tamanho Em Metros Quadrados</span>
+          </div>
+          <input
+            type="text"
+            name="txtArea"
+            oninput="formatarMetros(this)"
+            required
+          />
+        </div>
+
+        <div class="inputs">
+          <select name="txtSituacao" required>
+            <option value="">Situação...</option>
+            <option value="1">Disponível</option>
+            <option value="0">Indisponível</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="image">
+        <div>
+          <label class="form-label">Pré Visualização</label>
+          <img
+            style="display: block; margin: 0 auto; height: 300px"
+            src="assets/images/foto-chave.png"
+            id="img_foto"
+          />
+          <input type="hidden" id="txt_foto" name="txt_foto" />
+
+          <div class="inputs">
+            <input
+              type="file"
+              accept="image/*"
+              name="file_imagem"
+              id="file_imagem"
+              onchange="visualizarIMG(this)"
+            />
+          </div>
+        </div>
+
+        <input type="submit" value="Enviar" class="submit" />
+      </div>
     </form>
-</body>
+  </body>
 
-<script>
-    function voltar(){
-        window.location = "sistema.php"
+  <script>
+    function voltar() {
+      window.location = "sistema.php";
     }
 
     function formatarDinheiro(input) {
-        
-        let valor = input.value.replace(/[^\d]/g, '');
+      let valor = input.value.replace(/[^\d]/g, "");
 
-       
-        if (valor.length > 0) {
-            valor = new Intl.NumberFormat('pt-BR', {
-                style: 'currency',
-                currency: 'BRL'
-            }).format(Number(valor / 100)); 
-        }
+      if (valor.length > 0) {
+        valor = new Intl.NumberFormat("pt-BR", {
+          style: "currency",
+          currency: "BRL",
+        }).format(Number(valor / 100));
+      }
 
-        
-        input.value = valor;
+      input.value = valor;
     }
 
     function formatarMetros(input) {
-        // Remove caracteres não numéricos
-        let valor = input.value.replace(/[^\d.]/g, '');
+      // Remove caracteres não numéricos
+      let valor = input.value.replace(/[^\d.]/g, "");
 
-        // Formata o valor com até duas casas decimais
-        if (valor.length > 0) {
-            valor = new Intl.NumberFormat('pt-BR', {
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 2
-            }).format(Number(valor));
-        }
+      // Formata o valor com até duas casas decimais
+      if (valor.length > 0) {
+        valor = new Intl.NumberFormat("pt-BR", {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 2,
+        }).format(Number(valor));
+      }
 
-        // Atualiza o valor no input
-        input.value = valor + "m²"
+      // Atualiza o valor no input
+      input.value = valor + "m²";
     }
 
     function visualizarIMG(obj) {
-        var img = document.getElementById('img_foto');
-        var reader = new FileReader();
-        reader.onload = () => {
-        img.src =  reader.result
-        };
-        reader.readAsDataURL(obj.files[0]);
+      var img = document.getElementById("img_foto");
+      var reader = new FileReader();
+      reader.onload = () => {
+        img.src = reader.result;
+      };
+      reader.readAsDataURL(obj.files[0]);
     }
-</script>
+  </script>
 </html>


### PR DESCRIPTION
Usando o site notei que o formulário para cadastro de um novo imóvel não tinha nenhuma label nos inputs especificando para que servia, apenas um ícone, nesse pull request faço uma alteração no código, crio uma label descritiva para os inputs e coloco o ícone e a label dentro de uma ```div``` com a classe ```flex``` para alinhar os elementos horizontalmente: 

_novo-imovel.html_
```html
<div class="flex">
   <i class="bx bxs-car"></i>
   <span>Qtd. Vagas na Garagem</span>
</div>
```

_novo-imovel.css_

```css
.inputs .flex {
  display: flex;
  justify-content: center;
  gap: 2;
}

.inputs input {
  margin-top: 5px;
}
```



